### PR TITLE
Fix: Add https:// prefix to SHOPIFY_APP_URL

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 client_id = "60d2bee24f0b8aa368d185efb3544001"
 name = "shop-chat-agent"
 handle = "shop-chat-agent"
-application_url = "pb-chat-git.vercel.app"
+application_url = "https://pb-chat-git.vercel.app"
 embedded = true
 
 [build]
@@ -17,12 +17,12 @@ api_version = "2025-04"
 scopes = "customer_read_customers,customer_read_orders,customer_read_store_credit_account_transactions,customer_read_store_credit_accounts,unauthenticated_read_product_listings"
 
 [auth]
-redirect_urls = [ "pb-chat-git.vercel.app/api/auth" ]
+redirect_urls = [ "https://pb-chat-git.vercel.app/api/auth" ]
 
 [pos]
 embedded = false
 
 [mcp.customer_authentication]
 redirect_uris = [
-  "pb-chat-git.vercel.app/callback"
+  "https://pb-chat-git.vercel.app/callback"
 ]


### PR DESCRIPTION
- Updated SHOPIFY_APP_URL in .env to include https:// prefix.
- Updated application_url and redirect URIs in shopify.app.toml to include https:// prefix.

This resolves the 'TypeError: Invalid URL' error during the Vite build process that occurred because the URL was missing a protocol.