### PR TITLE
Fix: Add prisma generate to build script for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shop-chat-agent",
   "private": true,
   "scripts": {
-    "build": "remix vite:build",
+    "build": "prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",


### PR DESCRIPTION
- I updated the build script in package.json to run `prisma generate` before `remix vite:build`.

This ensures that Prisma Client is correctly generated in Vercel's build environment, resolving the PrismaClientInitializationError related to cached dependencies.