### PR TITLE
Fix: Resolve Prisma MissingSessionTableError for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shop-chat-agent",
   "private": true,
   "scripts": {
-    "build": "prisma generate && remix vite:build",
+    "build": "prisma migrate deploy && prisma generate && remix vite:build",
     "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ generator client {
 // enough when changing adapters.
 // See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = "file:dev.sqlite"
 }
 


### PR DESCRIPTION
- I updated the datasource provider in prisma/schema.prisma to 'postgresql' to match your Vercel environment.
- I updated the package.json build script to 'prisma migrate deploy && prisma generate && remix vite:build'.

This ensures the correct database provider is used, migrations are deployed to create tables, and Prisma client is generated before the application build on Vercel.