### PR TITLE
Fix: Correct Prisma datasource URL for PostgreSQL

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 // See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
   provider = "postgresql"
-  url      = "file:dev.sqlite"
+  url      = env("DATABASE_URL")
 }
 
 model Session {


### PR DESCRIPTION
- Update `url` in `prisma/schema.prisma`'s datasource block to `env("DATABASE_URL")`.

This ensures Prisma uses the DATABASE_URL environment variable for the connection string, which is necessary when using the 'postgresql' provider, especially for Vercel deployments.