### PR TITLE
Fix: Correct chat API URLs and MCP client endpoint construction

### DIFF
--- a/app/mcp-client.js
+++ b/app/mcp-client.js
@@ -20,8 +20,20 @@ class MCPClient {
     // TODO: Make this dynamic, for that first we need to allow access of mcp tools on password proteted demo stores.
     this.storefrontMcpEndpoint = `${hostUrl}/api/mcp`;
 
-    const accountHostUrl = hostUrl.replace(/(\.myshopify\.com)$/, '.account$1');
-    this.customerMcpEndpoint = customerMcpEndpoint || `${accountHostUrl}/customer/api/mcp`;
+    if (customerMcpEndpoint) {
+      this.customerMcpEndpoint = customerMcpEndpoint;
+    } else {
+      if (hostUrl && /\.myshopify\.com$/.test(hostUrl)) {
+        const accountHostUrl = hostUrl.replace(/(\.myshopify\.com)$/, '.account$1');
+        this.customerMcpEndpoint = `${accountHostUrl}/customer/api/mcp`;
+      } else {
+        this.customerMcpEndpoint = null;
+        console.warn(
+          `[MCPClient] customerMcpEndpoint could not be automatically determined for hostUrl "${hostUrl}". ` +
+          `Please provide it explicitly if customer-specific MCP tools are needed.`
+        );
+      }
+    }
     this.customerAccessToken = "";
     this.conversationId = conversationId;
     this.shopId = shopId;

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -408,7 +408,7 @@
             prompt_type: promptType
           });
 
-          const streamUrl = 'https://localhost:3458/chat';
+          const streamUrl = '/chat';
           const shopId = window.shopId;
 
           const response = await fetch(streamUrl, {
@@ -546,7 +546,7 @@
           messagesContainer.appendChild(loadingMessage);
 
           // Fetch history from the server
-          const historyUrl = `https://localhost:3458/chat?history=true&conversation_id=${encodeURIComponent(conversationId)}`;
+          const historyUrl = `/chat?history=true&conversation_id=${encodeURIComponent(conversationId)}`;
           console.log('Fetching history from:', historyUrl);
 
           const response = await fetch(historyUrl, {
@@ -700,7 +700,7 @@
           attemptCount++;
 
           try {
-            const tokenUrl = 'https://localhost:3458/auth/token-status?conversation_id=' +
+            const tokenUrl = '/auth/token-status?conversation_id=' +
               encodeURIComponent(conversationId);
             const response = await fetch(tokenUrl);
 


### PR DESCRIPTION
This commit addresses two main issues:
1. Hardcoded localhost URLs in the frontend chat client (`extensions/chat-bubble/assets/chat.js`):
    - Changed `streamUrl`, `historyUrl`, and `tokenUrl` to use relative paths (e.g., `/chat`) instead of `https://localhost:3458/...`. This ensures the chat client correctly calls the application's backend in deployed environments.
    - This resolves the observed 404 errors for `/null/chat` by ensuring requests target the correct application host and path.

2. Incorrect MCP (Model Context Protocol) endpoint construction in `app/mcp-client.js`:
    - Modified the logic for determining `customerMcpEndpoint`. It now prioritizes an explicitly passed endpoint.
    - If an explicit endpoint is not provided, it attempts to construct one from `hostUrl` only if `hostUrl` is a standard `*.myshopify.com` domain.
    - If `hostUrl` is a custom domain or a tunnel URL (e.g., `*.trycloudflare.com`) and no explicit `customerMcpEndpoint` is given, it sets the endpoint to `null` and logs a warning.
    - This prevents DNS resolution errors for malformed URLs like `strips-dt-thai-uses.trycloudflare.com.account/...` and makes the client more robust.

The instantiation of `MCPClient` in `app/routes/chat.jsx` was reviewed and deemed compatible with these changes, as it correctly fetches and passes the `customerMcpEndpoint`.

Recommended thorough manual testing to confirm resolution in all environments.