### PR TITLE
I've implemented a significant update that allows you to choose betwe…

### DIFF
--- a/app/services/gemini.server.js
+++ b/app/services/gemini.server.js
@@ -1,0 +1,361 @@
+/**
+ * Gemini Service
+ * Manages interactions with the Google Gemini API
+ */
+import AppConfig from "./config.server";
+import systemPrompts from "../prompts/prompts.json";
+
+// Helper to map OpenAPI/Claude schema types to Gemini schema types
+function mapTypeToGemini(claudeType) {
+  switch (claudeType) {
+    case "string":
+      return "STRING";
+    case "integer":
+      return "INTEGER";
+    case "number":
+      return "NUMBER";
+    case "boolean":
+      return "BOOLEAN";
+    // TODO: Add more type mappings if necessary (array, object etc.)
+    default:
+      return "STRING"; // Default to string if unknown
+  }
+}
+
+// Helper to transform Claude/OpenAPI tools to Gemini's FunctionDeclaration format
+function transformClaudeToolsToGemini(claudeTools) {
+  if (!claudeTools || claudeTools.length === 0) {
+    return [];
+  }
+
+  return claudeTools.map(tool => {
+    const properties = {};
+    if (tool.input_schema && tool.input_schema.properties) {
+      for (const key in tool.input_schema.properties) {
+        const prop = tool.input_schema.properties[key];
+        properties[key] = {
+          type: mapTypeToGemini(prop.type),
+          description: prop.description || "",
+        };
+      }
+    }
+
+    return {
+      name: tool.name,
+      description: tool.description || "",
+      parameters: {
+        type: "OBJECT", // Gemini uses "OBJECT" for object type parameters
+        properties: properties,
+        required: tool.input_schema && tool.input_schema.required ? tool.input_schema.required : [],
+      },
+    };
+  });
+}
+
+// Helper to transform Claude messages to Gemini format
+function formatMessagesForGemini(messages, systemInstruction) {
+  const geminiMessages = [];
+
+  // Add system instruction as the first message if provided
+  if (systemInstruction) {
+    // Gemini typically prefers system instructions either as a separate field 
+    // or as the first "model" message in a "user" initiated conversation.
+    // For simplicity here, we'll add it as a "user" message, then a "model" response.
+    // Or, if your prompt structure is different, adjust accordingly.
+    // A common pattern is:
+    // { role: "user", parts: [{ text: "System instruction here." }] },
+    // { role: "model", parts: [{ text: "Okay, I understand." }] }
+    // However, for direct instruction, sometimes just prepending to the first user message works,
+    // or using the `system_instruction` field if supported by the specific Gemini model endpoint.
+    // For gemini-pro through Vertex AI, system_instruction is a top-level field.
+    // For generativelanguage.googleapis.com, it's often part of the `contents`.
+    // We will add it as the first element in contents for now.
+    geminiMessages.push({ role: "user", parts: [{ text: systemInstruction }] });
+    geminiMessages.push({ role: "model", parts: [{ text: "Okay, I will follow these instructions." }] });
+  }
+
+  messages.forEach(msg => {
+    let role = msg.role;
+    if (role === "assistant") {
+      role = "model";
+    }
+    // Skip system messages if they were already handled or are not directly translatable
+    if (role !== "system") {
+      geminiMessages.push({
+        role: role,
+        parts: [{ text: msg.content }],
+      });
+    }
+  });
+  return geminiMessages;
+}
+
+
+/**
+ * Creates a Gemini service instance
+ * @param {string} apiKey - Gemini API key
+ * @returns {Object} Gemini service with methods for interacting with Gemini API
+ */
+export function createGeminiService(apiKey = process.env.GEMINI_API_KEY) {
+  /**
+   * Streams a conversation with Gemini
+   * @param {Object} params - Stream parameters
+   * @param {Array} params.messages - Conversation history (Claude format)
+   * @param {string} params.promptType - The type of system prompt to use
+   * @param {Array} params.tools - Available tools (Claude format) - currently logged, not passed to Gemini
+   * @param {Object} streamHandlers - Stream event handlers
+   * @param {Function} streamHandlers.sendMessage - Handles sending SSE messages to client
+   * @param {string} params.conversationId - The current conversation ID (optional, for event emulation)
+   * @returns {Promise<void>} Resolves when streaming is complete
+   */
+  const streamGeminiConversation = async ({
+    messages,
+    promptType = AppConfig.api.defaultPromptType,
+    tools,
+    conversationId // Used for emulating 'id' event
+  }, streamHandlers) => {
+    
+    if (!apiKey) {
+      console.error("Gemini API key is missing.");
+      streamHandlers.sendMessage({ type: 'error', error: { message: "Gemini API key is missing." } });
+      streamHandlers.sendMessage({ type: 'end_turn' });
+      return;
+    }
+
+    const systemInstruction = getSystemPrompt(promptType);
+    const formattedMessages = formatMessagesForGemini(messages, systemInstruction);
+    
+    let geminiToolsPayload = null;
+    if (tools && tools.length > 0) {
+      const transformedSchemas = transformClaudeToolsToGemini(tools);
+      if (transformedSchemas.length > 0) {
+        geminiToolsPayload = [{ functionDeclarations: transformedSchemas }];
+      }
+    }
+
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent?key=${apiKey}`;
+
+    const requestBody = {
+      contents: formattedMessages,
+      generationConfig: {
+        maxOutputTokens: AppConfig.api.maxTokens || 2048,
+        // Other configs like temperature, topP, topK can be added here
+      },
+      // safetySettings: [], // Add safety settings if needed
+    };
+
+    if (geminiToolsPayload) {
+      requestBody.tools = geminiToolsPayload;
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => response.text()); // Try to parse as JSON, fallback to text
+        console.error('Gemini API Error:', response.status, errorBody);
+        streamHandlers.sendMessage({ type: 'error', error: { message: `Gemini API Error: ${response.status}`, data: errorBody } });
+        streamHandlers.sendMessage({ type: 'end_turn' });
+        return;
+      }
+
+      // Emulate 'id' event if conversationId is available
+      if (conversationId) {
+        streamHandlers.sendMessage({ type: 'id', conversation_id: conversationId });
+      }
+      
+      let accumulatedText = "";
+      let toolCallDetectedThisTurn = false;
+
+      if (response.body) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done || toolCallDetectedThisTurn) { // Stop if tool call detected
+            break;
+          }
+
+          const chunk = decoder.decode(value, { stream: true });
+          const lines = chunk.split('\n');
+
+          for (const line of lines) {
+            if (line.trim() === "" || toolCallDetectedThisTurn) continue;
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.candidates && parsed.candidates.length > 0) {
+                const candidate = parsed.candidates[0];
+                if (candidate.content && candidate.content.parts && candidate.content.parts.length > 0) {
+                  const part = candidate.content.parts[0];
+                  if (part.functionCall) {
+                    console.log("[Gemini Service] Function call detected:", part.functionCall);
+                    streamHandlers.sendMessage({
+                      type: 'gemini_tool_call',
+                      name: part.functionCall.name,
+                      arguments: part.functionCall.args
+                    });
+                    // Signal message (the tool call itself) is complete for this turn
+                    streamHandlers.sendMessage({ type: 'message_complete' });
+                    toolCallDetectedThisTurn = true; 
+                    break; // Stop processing further parts/lines in this chunk
+                  } else if (part.text && !toolCallDetectedThisTurn) {
+                    streamHandlers.sendMessage({ type: 'chunk', chunk: part.text });
+                    accumulatedText += part.text;
+                  }
+                }
+                // TODO: Check for finishReason if needed, e.g. candidate.finishReason
+                // Could be 'TOOL_CALLS' or 'STOP' etc.
+              }
+            } catch (e) {
+              console.warn('[Gemini Service] Failed to parse JSON chunk part:', line, e);
+            }
+          }
+        }
+      }
+      
+      // If no tool call was detected and we have accumulated text, send message_complete for the text response.
+      if (!toolCallDetectedThisTurn && accumulatedText.length > 0) {
+        streamHandlers.sendMessage({ type: 'message_complete' });
+      }
+
+    } catch (error) {
+      console.error('Error streaming Gemini conversation:', error);
+      streamHandlers.sendMessage({ type: 'error', error: { message: error.message || "Unknown streaming error" } });
+    } finally {
+      streamHandlers.sendMessage({ type: 'end_turn' });
+    }
+  };
+
+  /**
+   * Gets the system prompt content for a given prompt type.
+   * For Gemini, this raw string will be incorporated into the `contents` array.
+   * @param {string} promptType - The prompt type to retrieve
+   * @returns {string} The system prompt content
+   */
+  const getSystemPrompt = (promptType) => {
+    return systemPrompts.systemPrompts[promptType]?.content ||
+      systemPrompts.systemPrompts[AppConfig.api.defaultPromptType].content;
+  };
+
+  return {
+    streamGeminiConversation,
+    getSystemPrompt,
+    streamGeminiResponseAfterToolExecution, // Export the new function
+  };
+}
+
+
+// New function to handle streaming response after a tool execution
+const streamGeminiResponseAfterToolExecution = async ({
+  apiKey = process.env.GEMINI_API_KEY,
+  existingMessages, // Gemini `Contents` format, including the model's part with the functionCall
+  toolName,
+  toolResponse, // This should be the JSON result from MCPClient.callTool
+  streamHandlers,
+  conversationId
+}) => {
+  if (!apiKey) {
+    console.error("[Gemini Service] API key is missing for tool response call.");
+    streamHandlers.sendMessage({ type: 'error', error: { message: "Gemini API key is missing." } });
+    streamHandlers.sendMessage({ type: 'end_turn' });
+    return;
+  }
+
+  // Construct the function response message part for Gemini
+  // Gemini expects the function response to be from the "user" role (or "function" role)
+  const functionResponseMessage = {
+    role: "user", // Using "user" as per common practice for function responses to Gemini
+    parts: [
+      {
+        functionResponse: {
+          name: toolName,
+          response: toolResponse, // Pass the raw toolResponse; Gemini expects an object.
+                                  // If toolResponse is a string, it might need to be wrapped e.g. { content: toolResponse }
+                                  // For now, assuming toolResponse is structured as the LLM expects.
+        }
+      }
+    ]
+  };
+  
+  const updatedMessages = [...existingMessages, functionResponseMessage];
+
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent?key=${apiKey}`;
+  const requestBody = {
+    contents: updatedMessages,
+    generationConfig: {
+      maxOutputTokens: AppConfig.api.maxTokens || 2048,
+    },
+    // Tools (function declarations) are omitted here, assuming a simple "tool -> result -> final text answer" flow.
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => response.text());
+      console.error('[Gemini Service] API Error after tool execution:', response.status, errorBody);
+      streamHandlers.sendMessage({ type: 'error', error: { message: `Gemini API Error: ${response.status}`, data: errorBody } });
+      streamHandlers.sendMessage({ type: 'end_turn' });
+      return;
+    }
+
+    if (conversationId) {
+      streamHandlers.sendMessage({ type: 'id', conversation_id: conversationId });
+    }
+
+    let accumulatedText = "";
+    if (response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const chunk = decoder.decode(value, { stream: true });
+        const lines = chunk.split('\n');
+        for (const line of lines) {
+          if (line.trim() === "") continue;
+          try {
+            const parsed = JSON.parse(line);
+            if (parsed.candidates && parsed.candidates.length > 0) {
+              const candidate = parsed.candidates[0];
+              // After a tool response, we expect only text parts, not another functionCall (since tools were omitted)
+              if (candidate.content && candidate.content.parts && candidate.content.parts[0].text) {
+                const textChunk = candidate.content.parts[0].text;
+                streamHandlers.sendMessage({ type: 'chunk', chunk: textChunk });
+                accumulatedText += textChunk;
+              }
+            }
+          } catch (e) {
+            console.warn('[Gemini Service] Failed to parse JSON chunk part after tool exec:', line, e);
+          }
+        }
+      }
+    }
+
+    if (accumulatedText.length > 0) {
+      streamHandlers.sendMessage({ type: 'message_complete' });
+    }
+
+  } catch (error) {
+    console.error('Error streaming Gemini response after tool execution:', error);
+    streamHandlers.sendMessage({ type: 'error', error: { message: error.message || "Unknown streaming error after tool execution" } });
+  } finally {
+    streamHandlers.sendMessage({ type: 'end_turn' });
+  }
+};
+
+
+export default {
+  createGeminiService,
+};

--- a/extensions/chat-bubble/assets/chat.js
+++ b/extensions/chat-bubble/assets/chat.js
@@ -402,10 +402,12 @@
 
         try {
           const promptType = window.shopChatConfig?.promptType || "standardAssistant";
+          const llmProvider = window.shopChatConfig?.llmProvider || 'claude';
           const requestBody = JSON.stringify({
             message: userMessage,
             conversation_id: conversationId,
-            prompt_type: promptType
+            prompt_type: promptType,
+            llm_provider: llmProvider
           });
 
           const streamUrl = '/chat';

--- a/extensions/chat-bubble/blocks/chat-interface.liquid
+++ b/extensions/chat-bubble/blocks/chat-interface.liquid
@@ -34,7 +34,8 @@
 <script>
   window.shopChatConfig = {
     promptType: {{ block.settings.system_prompt | json }},
-    welcomeMessage: {{ block.settings.welcome_message | json }}
+    welcomeMessage: {{ block.settings.welcome_message | json }},
+    llmProvider: {{ block.settings.llm_provider | json }}
   };
   window.shopId = {{ shop.id }};
 </script>
@@ -71,6 +72,22 @@
         }
       ],
       "default": "standardAssistant"
+    },
+    {
+      "type": "select",
+      "id": "llm_provider",
+      "label": "LLM Provider",
+      "options": [
+        {
+          "value": "claude",
+          "label": "Claude"
+        },
+        {
+          "value": "gemini",
+          "label": "Gemini"
+        }
+      ],
+      "default": "claude"
     }
   ]
 }


### PR DESCRIPTION
…en two different language models for our interactions.

Here's a summary of the changes:

1.  **Interface Settings:**
    *   I've added an "LLM Provider" option in the settings where you can select your preferred model.
    *   Your selection is then used to configure our chat.

2.  **Frontend Communication:**
    *   The interface now informs the backend about your chosen language model with each message you send.

3.  **Backend Services:**
    *   I've introduced a new way to interact with one of the language models directly. This includes managing how messages are exchanged and how I understand and use my capabilities.
    *   The existing way of interacting with the other language model remains in place.

4.  **Backend Logic:**
    *   I now dynamically choose which language model service to use based on your selection.
    *   I've also adjusted how I handle my internal processes depending on the chosen model.
    *   I've ensured that our conversation flow remains smooth regardless of which model is active.

5.  **Configuration:**
    *   The system will use the appropriate API key from the environment variables based on your selected language model.

These changes provide a flexible system, allowing you to select your preferred language model. You can test this by deploying the `feat/gemini-api-migration` branch and configuring the LLM provider in the theme settings.