### PR TITLE
I've added a document that compares Shopify chatbot applications.

### DIFF
--- a/shopify_chatbots_comparison.md
+++ b/shopify_chatbots_comparison.md
@@ -1,0 +1,117 @@
+# Shopify Chatbots Comparison
+
+## Tidio
+
+*   **Focus:** Live chat, chatbots, and email marketing for small to medium businesses.
+*   **Key Features:**
+    *   Live chat with customizable widgets.
+    *   AI-powered chatbots (Lyro) for automated responses.
+    *   Email marketing tools.
+    *   Integration with Messenger, Instagram, and other platforms.
+    *   Visitor tracking and analytics.
+*   **Shopify Integration:** Deep integration with Shopify, allowing for order tracking, abandoned cart recovery, and product recommendations directly within the chat.
+*   **Pricing:**
+    *   **Free:** Basic live chat, 50 chatbot conversations, email marketing (500 emails/month).
+    *   **Starter ($29/month billed annually):** Includes more chatbot conversations, basic analytics.
+    *   **Communicator ($25/month/agent billed annually):** Unlimited live chat conversations, advanced chat features.
+    *   **Chatbots ($29/month billed annually):** Unlimited chatbot conversations.
+    *   **Tidio+ ($394/month billed annually):** Custom chatbot triggers, dedicated support, advanced features.
+    *   **Lyro AI:** Starts at $39/month for 50 Lyro conversations.
+    *   **Trial:** 7-day free trial available for paid plans.
+
+## Shopify Inbox
+
+*   **Focus:** Free, simple messaging tool for Shopify merchants to manage customer conversations.
+*   **Key Features:**
+    *   Live chat for website and Shop app.
+    *   Automated quick replies and FAQs.
+    *   Order status updates within chat.
+    *   Basic customer management.
+    *   Assign chats to staff.
+*   **Shopify Integration:** Natively built into Shopify, providing seamless access to order data and customer profiles.
+*   **Pricing:**
+    *   **Free:** Included with all Shopify plans.
+
+## LiveChat
+
+*   **Focus:** Comprehensive live chat and customer service platform for businesses of all sizes.
+*   **Key Features:**
+    *   Feature-rich live chat with proactive chat invitations.
+    *   Ticketing system for offline and complex issues.
+    *   Chatbot capabilities (ChatBot).
+    *   Extensive reporting and analytics.
+    *   Integration with numerous third-party apps.
+*   **Shopify Integration:** Dedicated Shopify app that shows customer's cart details and order history in the chat window. Allows for product recommendations.
+*   **Pricing:**
+    *   **Starter ($20/agent/month billed annually):** Basic live chat, 60-day chat history.
+    *   **Team ($41/agent/month billed annually):** Full-featured live chat, basic reporting.
+    *   **Business ($59/agent/month billed annually):** Ticketing system, advanced reporting.
+    *   **Enterprise (Custom pricing):** Dedicated support, advanced security.
+    *   **ChatBot:** Starts at $52/month for 1000 successful chats.
+    *   **Trial:** 14-day free trial available.
+
+## Zendesk
+
+*   **Focus:** Omnichannel customer service platform, including support, sales, and customer engagement.
+*   **Key Features:**
+    *   Messaging across web, mobile, and social channels.
+    *   AI-powered bots for automation.
+    *   Integrated help center and knowledge base.
+    *   Advanced analytics and reporting.
+    *   Ticketing system.
+*   **Shopify Integration:** Robust integration shows customer and order data from Shopify within Zendesk. Allows processing refunds and cancellations.
+*   **Pricing:** (Zendesk Suite - includes messaging, ticketing, help center, and AI)
+    *   **Suite Team ($55/agent/month billed annually):** Ticketing system, messaging, basic automation.
+    *   **Suite Growth ($89/agent/month billed annually):** Self-service portal, advanced AI.
+    *   **Suite Professional ($115/agent/month billed annually):** Advanced reporting, custom roles.
+    *   **Trial:** 14-day free trial available. Zendesk also offers foundational support plans starting at $19/agent/month.
+
+## LiveAgent
+
+*   **Focus:** Multichannel help desk and live chat software with a strong emphasis on customer support.
+*   **Key Features:**
+    *   Live chat, email ticketing, call center, social media integration.
+    *   Universal inbox for all customer communications.
+    *   Extensive automation rules.
+    *   Built-in CRM.
+    *   Knowledge base.
+*   **Shopify Integration:** Integration displays customer order details within tickets and chat.
+*   **Pricing:**
+    *   **Small ($9/agent/month billed annually):** Email ticketing.
+    *   **Medium ($29/agent/month billed annually):** Email and live chat.
+    *   **Large ($49/agent/month billed annually):** All channels included.
+    *   **Enterprise ($69/agent/month billed annually):** All channels, advanced features, dedicated support.
+    *   **Trial:** 7-day or 14-day free trial available depending on the plan. A free plan with limited features is also available.
+
+## Tawk.to
+
+*   **Focus:** Completely free live chat software with optional paid add-ons for removing branding or hiring agents.
+*   **Key Features:**
+    *   Live chat with unlimited agents.
+    *   Ticketing system.
+    *   Knowledge base.
+    *   Mobile apps for iOS and Android.
+    *   Visitor tracking.
+*   **Shopify Integration:** Shopify app allows adding the Tawk.to widget to the store and tracking customer activity.
+*   **Pricing:**
+    *   **Free:** All core features are free.
+    *   **Optional Add-ons:**
+        *   Remove Tawk.to branding ($19/month).
+        *   Hire chat agents (starting at $1/hour).
+        *   AI Assist ($29/month).
+
+## Re:amaze
+
+*   **Focus:** Integrated customer service, live chat, and help desk platform for e-commerce businesses.
+*   **Key Features:**
+    *   Shared inbox for email, social media, SMS, and chat.
+    *   Live chat with automated chatbots ("Cues").
+    *   FAQ and knowledge base builder.
+    *   Order status push notifications.
+    *   Customer satisfaction surveys.
+*   **Shopify Integration:** Deep integration with Shopify, showing customer order data, allowing for refunds, cancellations, and product discussions within the chat.
+*   **Pricing:**
+    *   **Basic ($29/user/month billed annually):** Unlimited email inboxes, live chat, basic reporting.
+    *   **Pro ($49/user/month billed annually):** Live dashboard, advanced reporting, satisfaction surveys.
+    *   **Plus ($69/user/month billed annually):** Staff performance reporting, custom hosted FAQ.
+    *   **Trial:** 14-day free trial available.


### PR DESCRIPTION
This document provides a compiled list and comparison of several Shopify chatbot applications, including their key features, Shopify integration details, and pricing information.

The apps covered are:
- Tidio
- Shopify Inbox
- LiveChat
- Zendesk
- LiveAgent
- Tawk.to
- Re:amaze