### PR TITLE
fix: Resolve Vercel build errors

### DIFF
--- a/app/routes/chat.jsx
+++ b/app/routes/chat.jsx
@@ -246,12 +246,7 @@ async function handleChatSession({
     // for SSE events like 'chunk', 'id', 'message_complete', 'error', 'end_turn'.
     // It does not use onText, onMessage, onToolUse callbacks in the same way Claude SDK did.
     
-    // We need to collect the full assistant message to save it.
-    let assistantResponseText = "";
-    const originalSendMessage = stream.sendMessage;
-
-    // Wrap sendMessage to intercept chunks and build the full response
-    // and to handle message saving.
+    // Wrap sendMessage to intercept chunks, build the full response, and handle message saving.
     let assistantResponseText = "";
     const originalSendMessage = stream.sendMessage;
     let geminiToolCallEventData = null; // To store data from gemini_tool_call event

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  output   = "../node_modules/.prisma/client"
 }
 
 // Note that some adapters may set a maximum length for the String type by default, please ensure your strings are long


### PR DESCRIPTION
This commit addresses two issues identified in Vercel build logs:

1.  **Duplicate variable declarations in `app/routes/chat.jsx`**: Removed the redundant declarations of `assistantResponseText` and `originalSendMessage` within the `handleChatSession` function to prevent JavaScript errors.

2.  **Prisma generator output path warning**: Updated `prisma/schema.prisma` by adding `output = "../node_modules/.prisma/client"` to the `generator client` block. This explicitly sets the output path for the Prisma client, silencing the deprecation warning and ensuring compatibility with future Prisma versions.