### PR TITLE
refactor: Align ShopChatbotConfig with consolidated model & defaults

### DIFF
--- a/app/db.server.js
+++ b/app/db.server.js
@@ -56,7 +56,7 @@ function decrypt(text) {
 }
 
 const defaultShopChatbotConfig = {
-  llmProvider: null,
+  llmProvider: "gemini", // Updated to match schema default
   geminiApiKey: null,
   claudeApiKey: null,
   botName: "Store Assistant",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,7 +85,7 @@ model ShopChatbotConfig {
   shop                    String    @unique
 
   // LLM and API Key settings (existing)
-  llmProvider             String?
+  llmProvider             String?   @default("gemini")
   geminiApiKey            String? // Encrypted
   claudeApiKey            String? // Encrypted
 


### PR DESCRIPTION
This commit addresses Instruction 11 (Prisma Integration Review), ensuring the `ShopChatbotConfig` model, seed data, and database helpers are consistent and robust.

Key changes:

1.  **Prisma Schema (`prisma/schema.prisma`):**
    *   I reviewed the `ShopChatbotConfig` model against the consolidated example you provided in the project guidelines (Instruction 11).
    *   I updated the `llmProvider` field to include a database-level default: `llmProvider String? @default("gemini")`.
    *   Other existing fields (AI settings, UI settings, marketing UTMs, product display settings) were confirmed to be consistent with the relevant parts of the consolidated example.
    *   A new database migration will be required due to this schema change.

2.  **Seed Script (`prisma/seed.js`):**
    *   I verified that the `defaultShopData` (aliased as `defaultConfigData` in the file) used for seeding `ShopChatbotConfig` aligns with the updated schema, specifically ensuring `llmProvider` is set to "gemini". No changes to the seed script logic were necessary as it already reflected this.

3.  **Database Helpers (`app/db.server.js`):**
    *   I updated the application-level `defaultShopChatbotConfig` object to set `llmProvider: "gemini"`, aligning it with the new schema default.
    *   I verified that `getShopChatbotConfig` correctly returns this default for new shops and that `updateShopChatbotConfig` handles the `llmProvider` field appropriately.

These changes ensure that the `ShopChatbotConfig` model is accurately defined with appropriate defaults at both the schema and application levels, providing a consistent configuration baseline.