### PR TITLE
fix: Resolve Tooltip naming conflict in admin dashboard

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -22,7 +22,7 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip,
+  Tooltip as RechartsTooltip, // Aliased import
   Legend,
   ResponsiveContainer,
 } from 'recharts';
@@ -154,7 +154,7 @@ export default function Index() {
                           // tickFormatter={(tickItem) => new Date(tickItem).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                         />
                         <YAxis allowDecimals={false} />
-                        <Tooltip />
+                        <RechartsTooltip /> {/* Updated usage */}
                         <Legend />
                         <Line type="monotone" dataKey="count" stroke="#8884d8" activeDot={{ r: 8 }} name="Interactions" />
                       </LineChart>


### PR DESCRIPTION
This commit fixes a JavaScript error in `app/routes/app._index.jsx` where the `Tooltip` component was being imported from both `@shopify/polaris` and `recharts`, causing a naming conflict and a build failure ("The symbol 'Tooltip' has already been declared").

The fix involves:
1.  Aliasing the `Tooltip` component imported from the `recharts` library to `RechartsTooltip`.
2.  Updating the usage of this aliased component within the `<LineChart>` to `<RechartsTooltip />`.

The `Tooltip` imported from `@shopify/polaris` continues to be used as `<Tooltip />` for other UI elements on the page. This change ensures that both components can be used distinctly without conflict.